### PR TITLE
add '/ip' to force return ip only

### DIFF
--- a/server.py
+++ b/server.py
@@ -29,8 +29,11 @@ def main():
                 enco=request.accept_encodings,
                 xip=request.access_route[0]
                 )
-    
-    
+
+@app.route('/ip')
+def ip():
+    return request.remote_addr + "\n"
+
 @app.route('/ip.host')
 def iphost():
     hostname=lookup(request.remote_addr)[0]

--- a/templates/main.html
+++ b/templates/main.html
@@ -13,6 +13,9 @@ Feature list:
 $curl ifconfig.pro
 1.1.1.1
 
+$curl ifconfig.pro/ip
+1.1.1.1
+
 $curl ifconfig.pro/ip.host
 1.1.1.1 r.d.ns.look.up
 


### PR DESCRIPTION
Create a way to force only return ip. Not judged by whether User-Agent contains 'curl' or 'PowerShell'. Make it more sensible and elegant when only getting ip not through curl and PowerShell, which do not need to modify User-Agent.